### PR TITLE
Fix https in demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <html>
 	<head>
 		<title>MorMap</title>
-		<script type="text/javascript" src="http://maps.google.com/maps/api/js?key=AIzaSyCcdl2nD-CXNSBNpxD3mm6micqLMFRA9PE"></script>
-		<script type="text/javascript" src="http://code.jquery.com/jquery-3.1.1.min.js"></script>
+		<script type="text/javascript" src="https://maps.google.com/maps/api/js?key=AIzaSyCcdl2nD-CXNSBNpxD3mm6micqLMFRA9PE"></script>
+		<script type="text/javascript" src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
 		<!-- from https://raw.githubusercontent.com/googlemaps/v3-utility-library/master/infobubble/src/infobubble-compiled.js -->
 		<script type="text/javascript" src="demo/infobubble-compiled.js"></script>
 		<script type="text/javascript" src="locations.js"></script>


### PR DESCRIPTION
The demo page at [https://mortorqrobotics.github.io/mormap-data](https://mortorqrobotics.github.io/mormap-data) is not working since it is loaded over https but the script urls have http